### PR TITLE
Download the videos to be shown in the template

### DIFF
--- a/MediaPlayer.py
+++ b/MediaPlayer.py
@@ -9,6 +9,7 @@ import json
 import uuid
 import configparser
 import utils
+import urllib.request
 from protocol import MessageProtocol
 
 def on_connect(client, userdata, flags, reason_code, properties):
@@ -39,6 +40,13 @@ def on_message(client, userdata, msg):
         registered = True
 
     elif(method == "TEMPLATE"):
+
+        files = message["files"]
+        if isinstance(files, list) and len(files) != 0:
+            for url in files:
+                filename = url.split("/")[-1]
+                urllib.request.urlretrieve(url, "static/" + filename)
+
         utils.store_static("current.html", message["html"])
         window.load_url(utils.get_full_path("static/current.html"))
 

--- a/MediaPlayer.py
+++ b/MediaPlayer.py
@@ -45,17 +45,7 @@ def on_message(client, userdata, msg):
         files = message["files"]
         if isinstance(files, list) and len(files) != 0:
             for url in files:
-                response = requests.head(url)
-                if "Content-Disposition" in response.headers:
-                    content_disposition = response.headers["Content-Disposition"]
-                    filename_index = content_disposition.find("filename=")
-                    if filename_index != -1:
-                        filename = content_disposition[filename_index + len("filename="):]
-                        filename = filename.strip('"')
-                        
-                        response = requests.get(url)
-                        with open(os.path.join("static", filename), "wb") as file:
-                            file.write(response.content)
+                utils.download_file(url, "static")
 
         utils.store_static("current.html", message["html"])
         window.load_url(utils.get_full_path("static/current.html"))

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,7 @@
 import os
 from screeninfo import get_monitors
 import re
+import requests
 
 # strip html from string
 def striphtml(data):
@@ -22,3 +23,19 @@ def get_monitor_size():
 def store_static(filename, content):
     with open("static/" + filename, 'w') as file:
         file.write(content)
+
+# download a file to a specific path
+def download_file(url, path_to_save):
+    response = requests.head(url)
+
+    if "Content-Disposition" in response.headers:
+        content_disposition = response.headers["Content-Disposition"]
+        filename_index = content_disposition.find("filename=")
+        filename = content_disposition[filename_index + len("filename="):]
+        filename = filename.strip('"')
+    else:
+        filename = url.split("/")[-1]
+                        
+    response = requests.get(url)
+    with open(os.path.join(path_to_save, filename), "wb") as file:
+        file.write(response.content)


### PR DESCRIPTION
Made it so when the MediaPlayer receives a message with a template it goes through each of the urls in the message and and downloads all the files to the static folder. Also made it so it checks for the filename in the headers since that is how we are currently doing it in the backend.

Tested it with backend branch 103.