### PR TITLE
Send keep alive messages to the broker periodically

### DIFF
--- a/default_config.ini
+++ b/default_config.ini
@@ -6,7 +6,7 @@ host = localhost
 port = 1883
 
 # Default keep-alive interval (in seconds)
-keepalive = 60
+keepalive_mqtt = 60
 
 # Default credentials for the MQTT Broker
 username = test
@@ -21,6 +21,12 @@ register_topic = register
 # Default transport method 
 # the options are ['tcp', 'websockets']
 transport = tcp
+
+# Default keep-alive logs interval (in seconds)
+keepalive_logs_delay = 300
+
+# Default topic for sending keepalive message
+keepalive_logs_topic = keepalive
 
 [MediaPlayer]
 # Default HTML template for GUI window

--- a/protocol.py
+++ b/protocol.py
@@ -8,6 +8,6 @@ class MessageProtocol:
         return json.dumps(message)
 
     @classmethod
-    def log(cls, logs, uuid):
-        message = { "method":"LOG", "logs": logs, "uuid":uuid }
+    def keep_alive(cls, uuid):
+        message = { "method":"KEEP_ALIVE", "uuid":uuid }
         return json.dumps(message)


### PR DESCRIPTION
### Issue

Closes #15.

### Reason for this change

This is being added so that the backend can know if the Media Player is still alive

### Description of changes

Added a keep alive thread that is responsible for sending the message.
Also added options in the config to change the keepalive topic and the delay between the messages.

### Description of how you validated changes

Seems to be working with current version of the backend

### Checklist
- [x] I have tested my changes locally.
- [x] I have updated the documentation to reflect my changes.
- [ ] I have added/updated unit tests (if applicable).
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://ua-smart-signage-platform.github.io/Documentation-Website/guidelines/)